### PR TITLE
Added config support

### DIFF
--- a/basic/config/Config.php
+++ b/basic/config/Config.php
@@ -32,8 +32,8 @@ class Config
 
     public static function delete($key)
     {
-        Yii::$app->db->createCommand()
-            ->delete('config', ['key' => $key])
+        Yii::$app->db->createCommand('DELETE FROM config WHERE `key` = :key')
+            ->bindValue(':key', $key)
             ->execute();
 
         Yii::$app->cache->delete(self::CACHE_KEY);

--- a/basic/config/Config.php
+++ b/basic/config/Config.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace app\config;
+
+use Yii;
+
+class Config
+{
+    const CACHE_KEY = 'app_config';
+
+    public static function get($key, $default = null)
+    {
+        $config = Yii::$app->cache->get(self::CACHE_KEY);
+
+        if ($config === false) {
+            $config = Yii::$app->db->createCommand('SELECT `key`, `value` FROM config')
+                ->queryAll(\PDO::FETCH_KEY_PAIR);
+            Yii::$app->cache->set(self::CACHE_KEY, $config);
+        }
+
+        return isset($config[$key]) ? $config[$key] : $default;
+    }
+
+    public static function set($key, $value)
+    {
+        Yii::$app->db->createCommand()
+            ->upsert('config', ['key' => $key, 'value' => $value])
+            ->execute();
+
+        Yii::$app->cache->delete(self::CACHE_KEY);
+    }
+
+    public static function delete($key)
+    {
+        Yii::$app->db->createCommand()
+            ->delete('config', ['key' => $key])
+            ->execute();
+
+        Yii::$app->cache->delete(self::CACHE_KEY);
+    }
+}

--- a/basic/config/test.php
+++ b/basic/config/test.php
@@ -28,6 +28,9 @@ return [
         'urlManager' => [
             'showScriptName' => true,
         ],
+        'cache' => [
+            'class' => 'yii\caching\FileCache',
+        ],
         'user' => [
             'identityClass' => 'app\models\User',
         ],

--- a/basic/controllers/PilotController.php
+++ b/basic/controllers/PilotController.php
@@ -2,9 +2,11 @@
 
 namespace app\controllers;
 
+use app\config\Config;
 use app\models\Country;
 use app\models\Pilot;
 use app\models\PilotSearch;
+use DateTime;
 use yii\web\Controller;
 use yii\web\ForbiddenHttpException;
 use yii\web\NotFoundHttpException;
@@ -77,10 +79,21 @@ class PilotController extends Controller
     public function actionRegister()
     {
 
-        // TODO: MOVE TO CONFIGURATION STORED IN DB
-        $registration_is_closed = false;
+        $registrationStart = DateTime::createFromFormat('Y-m-d', Config::get('registration_start'));
+        $registrationEnd = DateTime::createFromFormat('Y-m-d', Config::get('registration_end'));
 
-        if($registration_is_closed) {
+        if ($registrationStart === false || $registrationEnd === false) {
+            throw new Exception("Invalid registration dates. Contact an admin.");
+        }
+
+        Yii::warning($registrationStart);
+        Yii::warning($registrationEnd);
+
+        $now = new DateTime();
+
+        Yii::warning($now);
+
+        if($now < $registrationStart || $now > $registrationEnd) {
             return $this->render('registration_closed');
         } else {
             $model = new Pilot();

--- a/basic/tests/unit/DbTestCase.php
+++ b/basic/tests/unit/DbTestCase.php
@@ -15,6 +15,7 @@ abstract class DbTestCase extends \Codeception\Test\Unit
     protected function clearDatabase()
     {
         $db = Yii::$app->db;
+        Yii::$app->db->createCommand()->delete('config')->execute();
         Yii::$app->db->createCommand()->delete('aircraft')->execute();
         Yii::$app->db->createCommand()->delete('pilot')->execute();
         Yii::$app->db->createCommand()->delete('route')->execute();

--- a/basic/tests/unit/config/ConfigTest.php
+++ b/basic/tests/unit/config/ConfigTest.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace tests\unit\config;
+
+use app\config\Config;
+use tests\unit\DbTestCase;
+use Yii;
+use DateTime;
+
+class ConfigTest extends DbTestCase
+{
+    protected function _before()
+    {
+        parent::_before();
+        Yii::$app->cache->flush();
+    }
+
+    public function testSetAndGetDate()
+    {
+        Config::set('registration_start', '2024-12-01');
+        Config::set('registration_end', '2024-12-31');
+
+        $registrationStart = DateTime::createFromFormat('Y-m-d', Config::get('registration_start'));
+        $registrationEnd = DateTime::createFromFormat('Y-m-d', Config::get('registration_end'));
+
+        $this->assertInstanceOf(DateTime::class, $registrationStart);
+        $this->assertInstanceOf(DateTime::class, $registrationEnd);
+        $this->assertEquals('2024-12-01', $registrationStart->format('Y-m-d'));
+        $this->assertEquals('2024-12-31', $registrationEnd->format('Y-m-d'));
+    }
+
+    public function testSetAndGetUrl()
+    {
+        Config::set('logo_url', 'https://example.com/logo.png');
+        $logoUrl = Config::get('logo_url');
+        $this->assertEquals('https://example.com/logo.png', $logoUrl);
+    }
+
+    public function testSetAndGetText()
+    {
+        Config::set('welcome_message', 'Welcome to our site!');
+        $welcomeMessage = Config::get('welcome_message');
+        $this->assertEquals('Welcome to our site!', $welcomeMessage);
+    }
+
+    public function testSetAndGetHtml()
+    {
+        $htmlContent = '<div><h1>Welcome</h1><p>This is a test</p></div>';
+        Config::set('embedded_html', $htmlContent);
+        $retrievedHtml = Config::get('embedded_html');
+        $this->assertEquals($htmlContent, $retrievedHtml);
+    }
+
+    public function testDefaultValue()
+    {
+        $defaultValue = Config::get('non_existing_key', 'default_value');
+        $this->assertEquals('default_value', $defaultValue);
+    }
+
+    public function testDeleteConfig()
+    {
+        Config::set('temporary_key', 'temporary_value');
+        $this->assertEquals('temporary_value', Config::get('temporary_key'));
+
+        Config::delete('temporary_key');
+        $this->assertNull(Config::get('temporary_key'));
+    }
+}

--- a/basic/tests/unit/models/AircraftConfigurationTest.php
+++ b/basic/tests/unit/models/AircraftConfigurationTest.php
@@ -1,5 +1,5 @@
 <?php
-namespace tests\unit;
+namespace tests\unit\models;
 
 use app\models\AircraftConfiguration;
 use app\models\AircraftType;

--- a/db-model/config.sql
+++ b/db-model/config.sql
@@ -1,0 +1,2 @@
+INSERT INTO config(`key`, `value`) VALUES ('registration_start', '2024-12-10');
+INSERT INTO config(`key`, `value`) VALUES ('registration_end', '2025-12-10');

--- a/db-model/ddl.sql
+++ b/db-model/ddl.sql
@@ -1,5 +1,13 @@
 -- CREATE DATABASE `mam` /*!40100 DEFAULT CHARACTER SET utf8mb4 */;
 
+CREATE TABLE `config` (
+  `key` varchar(255) NOT NULL,
+  `value` text NOT NULL,
+  `created_at` timestamp NOT NULL DEFAULT current_timestamp(),
+  `updated_at` timestamp NOT NULL DEFAULT current_timestamp() ON UPDATE current_timestamp(),
+  PRIMARY KEY (`key`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
 CREATE TABLE `country` (
   `id` int(10) unsigned NOT NULL AUTO_INCREMENT,
   `name` varchar(80) NOT NULL,


### PR DESCRIPTION
* The table config is used as key value backed by a cache, in order to save some parameters affected by the application (Ex: registration dates, emails, logo urls... etc)