### PR TITLE
Fix VFR Report flights

### DIFF
--- a/basic/models/Flight.php
+++ b/basic/models/Flight.php
@@ -53,7 +53,7 @@ class Flight extends \yii\db\ActiveRecord
     public function rules()
     {
         return [
-            [['pilot_id', 'aircraft_id', 'code', 'departure', 'arrival', 'alternative1_icao', 'flight_rules', 'cruise_speed_value', 'cruise_speed_unit', 'flight_level_value', 'flight_level_unit', 'route', 'estimated_time', 'other_information', 'endurance_time', 'report_tool'], 'required'],
+            [['pilot_id', 'aircraft_id', 'code', 'departure', 'arrival', 'alternative1_icao', 'flight_rules', 'cruise_speed_value', 'cruise_speed_unit', 'flight_level_unit', 'route', 'estimated_time', 'other_information', 'endurance_time', 'report_tool'], 'required'],
             [['pilot_id', 'aircraft_id'], 'integer'],
             [['creation_date'], 'safe'],
             [['code'], 'string', 'max' => 10],

--- a/basic/tests/unit/models/FlightTest.php
+++ b/basic/tests/unit/models/FlightTest.php
@@ -116,7 +116,6 @@ class FlightTest extends BaseUnitTest
         $this->assertArrayHasKey('flight_rules', $model->getErrors(), 'Missing error for flight_rules.');
         $this->assertArrayHasKey('cruise_speed_value', $model->getErrors(), 'Missing error for cruise_speed_value.');
         $this->assertArrayHasKey('cruise_speed_unit', $model->getErrors(), 'Missing error for cruise_speed_unit.');
-        $this->assertArrayHasKey('flight_level_value', $model->getErrors(), 'Missing error for flight_level_value.');
         $this->assertArrayHasKey('flight_level_unit', $model->getErrors(), 'Missing error for flight_level_unit.');
         $this->assertArrayHasKey('route', $model->getErrors(), 'Missing error for route.');
         $this->assertArrayHasKey('estimated_time', $model->getErrors(), 'Missing error for estimated_time.');


### PR DESCRIPTION
* Flight level value can be blank, because in VFR flights, VFR unit can be used without values.