### PR TITLE
Ignore already uploaded chunks

### DIFF
--- a/basic/models/Flight.php
+++ b/basic/models/Flight.php
@@ -111,8 +111,8 @@ class Flight extends \yii\db\ActiveRecord
         );
     }
 
-    public function isOpenForUpload(){
-        return $this->status === 'C';
+    public function isProcessed(){
+        return $this->status === 'V' || $this->status === 'F';
     }
 
     /**

--- a/basic/tests/api/v1/flightReport/UploadChunkCest.php
+++ b/basic/tests/api/v1/flightReport/UploadChunkCest.php
@@ -66,7 +66,7 @@ class UploadChunkCest
         ]);
     }
 
-    public function testFlightProcessed(ApiTester $I)
+    public function testFlightClosedForUpload(ApiTester $I)
     {
         $this->loginAsUser(5, $I);
 

--- a/basic/tests/api/v1/flightReport/UploadChunkCest.php
+++ b/basic/tests/api/v1/flightReport/UploadChunkCest.php
@@ -66,22 +66,6 @@ class UploadChunkCest
         ]);
     }
 
-    public function testChunkAlreadyUploaded(ApiTester $I)
-    {
-        $chunk = \app\models\AcarsFile::findOne(['chunk_id' => 1, 'flight_report_id' => 2]);
-        $chunk->upload_date = date('Y-m-d H:i:s');
-        $chunk->save();
-
-        $this->loginAsUser(5, $I);
-        $filePath = $this->getTestFilePath('2_1.tmp');
-        $I->sendPOST('/flight-report/upload-chunk/?flight_report_id=2&chunk_id=1', [], ['chunkFile' => $filePath]);
-        $I->seeResponseCodeIs(409);
-        $I->seeResponseContainsJson([
-            'name' => 'Conflict',
-            'message' => 'Chunk 1 already uploaded.',
-        ]);
-    }
-
     public function testFlightClosed(ApiTester $I)
     {
         $this->loginAsUser(5, $I);
@@ -96,13 +80,6 @@ class UploadChunkCest
 
         $this->loginAsUser(7, $I);
         $I->sendPOST('/flight-report/upload-chunk/?flight_report_id=3&chunk_id=2', [], ['chunkFile' => $filePath]);
-        $I->seeResponseCodeIs(404);
-        $I->seeResponseContainsJson([
-            'name' => 'Not Found',
-            'message' => 'Flight access denied or not available for chunk uploads.',
-        ]);
-
-        $I->sendPOST('/flight-report/upload-chunk/?flight_report_id=4&chunk_id=1', [], ['chunkFile' => $filePath]);
         $I->seeResponseCodeIs(404);
         $I->seeResponseContainsJson([
             'name' => 'Not Found',
@@ -155,5 +132,20 @@ class UploadChunkCest
         $flight_report = \app\models\FlightReport::findOne(['id' => 5]);
         $flight = \app\models\Flight::findOne(['id' => $flight_report->flight_id]);
         $I->assertEquals('S', $flight->status);
+    }
+
+    public function ignoreUploadSameChunkIfFlightIsNotProcessed(ApiTester $I)
+    {
+        // If the flight is not processed('C' or 'S') and chunk is already uploaded ignore and return 200 for client
+        $this->loginAsUser(7, $I);
+
+        $filePath = $this->getTestFilePath('2_1.tmp');
+
+        $I->sendPOST('/flight-report/upload-chunk/?flight_report_id=4&chunk_id=1', [], ['chunkFile' => $filePath]);
+        $I->seeResponseCodeIs(200);
+        $I->seeResponseContainsJson(['status' => 'success']);
+
+        $chunk = \app\models\AcarsFile::findOne(['flight_report_id' => 4,'chunk_id' => 1]);
+        $I->assertSame('2025-01-01 02:01:05', $chunk->upload_date);
     }
 }

--- a/basic/tests/api/v1/flightReport/UploadChunkCest.php
+++ b/basic/tests/api/v1/flightReport/UploadChunkCest.php
@@ -66,7 +66,7 @@ class UploadChunkCest
         ]);
     }
 
-    public function testFlightClosed(ApiTester $I)
+    public function testFlightProcessed(ApiTester $I)
     {
         $this->loginAsUser(5, $I);
 

--- a/basic/tests/fixtures/data/flight.php
+++ b/basic/tests/fixtures/data/flight.php
@@ -66,8 +66,8 @@ return [
         'other_information' => 'DOF/20241205 REG/ECDDD OPR/XXX',
         'endurance_time' => '0500',
         'report_tool' => 'Mam Acars 1.0',
-        'status' => 'S',
-        'creation_date' => '2025-01-02 02:00:00',
+        'status' => 'V',
+        'creation_date' => '2025-01-02 01:00:00',
         'network' => 'Vatsim'
     ],
     [
@@ -89,7 +89,7 @@ return [
         'other_information' => 'DOF/20241205 REG/ECDDD OPR/XXX',
         'endurance_time' => '0500',
         'report_tool' => 'Mam Acars 1.0',
-        'status' => 'V',
+        'status' => 'S',
         'creation_date' => '2025-01-02 02:00:00',
         'network' => 'Vatsim'
     ],


### PR DESCRIPTION
If we are uploading a chunk already uploaded and our report hasn't been processed, just ignore it returning 200. 

This change will allow mam-acars to continue if some of the requests was processed without retrieve the response.
