### PR TITLE
Small fixes related with search and renewal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [1.11.1] - upcoming
+## [1.11.1] - 2026-05-12
 
 ### Fixed
 - Aircraft index search by name no longer throws an integrity constraint violation when aircraft type and configuration tables are joined (ambiguous `name` column now qualified as `aircraft.name`)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Fixed
 - Aircraft index search by name no longer throws an integrity constraint violation when aircraft type and configuration tables are joined (ambiguous `name` column now qualified as `aircraft.name`)
+- Renewing a license no longer sets an expiry date on descendant ratings that had none (null expiry is now preserved in cascade)
+- Renewing a credential with the "Does not expire" checkbox now correctly removes the expiry date instead of rejecting the form with a validation error
 
 ## [1.11.0] - 2026-05-04
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [1.11.1] - upcoming
+
+### Fixed
+- Aircraft index search by name no longer throws an integrity constraint violation when aircraft type and configuration tables are joined (ambiguous `name` column now qualified as `aircraft.name`)
+
 ## [1.11.0] - 2026-05-04
 
 ### Added

--- a/basic/config/params.php
+++ b/basic/config/params.php
@@ -4,5 +4,5 @@ return [
     'adminEmail' => 'admin@example.com',
     'senderEmail' => 'noreply@example.com',
     'senderName' => 'Example.com mailer',
-    'version' => '1.11.0',
+    'version' => '1.11.1',
 ];

--- a/basic/controllers/PilotCredentialController.php
+++ b/basic/controllers/PilotCredentialController.php
@@ -419,9 +419,13 @@ class PilotCredentialController extends Controller
         $updated = PilotCredential::updateAll(
             ['expiry_date' => $license->expiry_date],
             [
-                'pilot_id'           => $license->pilot_id,
-                'credential_type_id' => $ratingTypeIds,
-                'status'             => PilotCredential::STATUS_ACTIVE,
+                'and',
+                [
+                    'pilot_id'           => $license->pilot_id,
+                    'credential_type_id' => $ratingTypeIds,
+                    'status'             => PilotCredential::STATUS_ACTIVE,
+                ],
+                ['not', ['expiry_date' => null]],
             ]
         );
         if ($updated > 0) {

--- a/basic/controllers/PilotCredentialController.php
+++ b/basic/controllers/PilotCredentialController.php
@@ -290,6 +290,10 @@ class PilotCredentialController extends Controller
         if ($this->request->isPost && $model->load($this->request->post())) {
             $model->issued_date = $originalIssuedDate;
 
+            if ($model->expiry_date === '') {
+                $model->expiry_date = null;
+            }
+
             if ($model->expiry_date !== null && $model->expiry_date <= date('Y-m-d')) {
                 $model->addError('expiry_date', Yii::t('app', 'Expiry date must be after today.'));
             }

--- a/basic/models/AircraftSearch.php
+++ b/basic/models/AircraftSearch.php
@@ -116,7 +116,10 @@ class AircraftSearch extends Aircraft
             'sort'  => [
                 'attributes' => [
                     'registration',
-                    'name',
+                    'name' => [
+                        'asc'  => ['aircraft.name' => SORT_ASC],
+                        'desc' => ['aircraft.name' => SORT_DESC],
+                    ],
                     'location',
                     'hours_flown',
                     'aircraftConfiguration' => [
@@ -144,7 +147,7 @@ class AircraftSearch extends Aircraft
         ]);
 
         $query->andFilterWhere(['like', 'registration', $this->registration])
-            ->andFilterWhere(['like', 'name', $this->name])
+            ->andFilterWhere(['like', 'aircraft.name', $this->name])
             ->andFilterWhere(['like', 'location', $this->location]);
 
         return $dataProvider;

--- a/basic/tests/functional/aircraft/AircraftIndexViewCest.php
+++ b/basic/tests/functional/aircraft/AircraftIndexViewCest.php
@@ -133,5 +133,15 @@ class AircraftIndexViewCest
         $I->see('Login');
     }
 
+    public function searchByNameFiltersAircraftOnly(\FunctionalTester $I)
+    {
+        $I->amOnRoute('aircraft/index', ['AircraftSearch[name]' => 'C172']);
+
+        $I->see('Showing 1-2 of 2 items.');
+        $I->see('C172 Std');
+        $I->see('C172 Other');
+        $I->dontSee('Boeing Name Std');
+        $I->dontSee('Boeing Name Cargo');
+    }
 
 }

--- a/basic/tests/functional/pilotCredential/PilotCredentialRenewCest.php
+++ b/basic/tests/functional/pilotCredential/PilotCredentialRenewCest.php
@@ -173,6 +173,42 @@ class PilotCredentialRenewCest
         $I->assertNull($irAfter->expiry_date);
     }
 
+    public function renewRemovesExpiryDate(\FunctionalTester $I)
+    {
+        // id=3: John Doe IR, active, expiry='2027-01-10' → remove expiry by submitting empty string
+        $I->amLoggedInAs(2);
+        $I->sendAjaxPostRequest('/pilot-credential/renew?id=3', [
+            'PilotCredential' => [
+                'status'      => PilotCredential::STATUS_ACTIVE,
+                'issued_date' => '2025-01-10',
+                'expiry_date' => '',
+                'pilot_id'    => 1,
+                'issued_by'   => 2,
+            ],
+        ]);
+
+        $pc = PilotCredential::findOne(3);
+        $I->assertNull($pc->expiry_date);
+    }
+
+    public function renewAddsExpiryToNullExpiryCredential(\FunctionalTester $I)
+    {
+        // id=1: John Doe PPL, active, null expiry → add a future expiry date
+        $I->amLoggedInAs(2);
+        $I->sendAjaxPostRequest('/pilot-credential/renew?id=1', [
+            'PilotCredential' => [
+                'status'      => PilotCredential::STATUS_ACTIVE,
+                'issued_date' => '2024-01-15',
+                'expiry_date' => '2028-12-31',
+                'pilot_id'    => 1,
+                'issued_by'   => 2,
+            ],
+        ]);
+
+        $pc = PilotCredential::findOne(1);
+        $I->assertEquals('2028-12-31', $pc->expiry_date);
+    }
+
     public function renewNonExistent(\FunctionalTester $I)
     {
         $I->amLoggedInAs(2);

--- a/basic/tests/functional/pilotCredential/PilotCredentialRenewCest.php
+++ b/basic/tests/functional/pilotCredential/PilotCredentialRenewCest.php
@@ -149,6 +149,30 @@ class PilotCredentialRenewCest
         $I->assertEquals('2028-01-01', $ir->expiry_date);
     }
 
+    public function renewLicenseDoesNotCascadeToRatingWithoutExpiry(\FunctionalTester $I)
+    {
+        // Set IR (id=9) to null expiry — it should never gain an expiry via cascade
+        $ir = PilotCredential::findOne(9);
+        $ir->expiry_date = null;
+        $ir->save(false);
+
+        // Renew CPL (id=8) for pilot 6
+        $I->amLoggedInAs(2);
+        $I->amOnRoute('pilot-credential/renew', ['id' => 8]);
+
+        $I->fillField('#pilotcredential-expiry_date', '2028-01-01');
+        $I->click('Save', 'button');
+
+        $I->seeResponseCodeIs(200);
+
+        $cpl = PilotCredential::findOne(8);
+        $I->assertEquals('2028-01-01', $cpl->expiry_date);
+
+        // IR had no expiry — cascade must not assign one
+        $irAfter = PilotCredential::findOne(9);
+        $I->assertNull($irAfter->expiry_date);
+    }
+
     public function renewNonExistent(\FunctionalTester $I)
     {
         $I->amLoggedInAs(2);


### PR DESCRIPTION
* Aircraft index search by name no longer throws an integrity constraint violation when aircraft type and configuration tables are joined (ambiguous `name` column now qualified as `aircraft.name`)
* Renewing a license no longer sets an expiry date on descendant ratings that had none (null expiry is now preserved in cascade)
* Renewing a credential with the "Does not expire" checkbox now correctly removes the expiry date instead of rejecting the form with a validation error
