### PR TITLE
Make checked baggage ratio configurable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Added
 - Pilot detail view: "Recent flights" table now shows a status icon (with tooltip) for each flight, matching the flight list view
 - `FlightStatusIconHelper::renderIcon()` centralizes the status icon markup, now shared by the flight list and pilot detail views
+- Admin settings → Occupancy Ratios: configurable checked-baggage ratio (default 20–35%), replacing the previously hardcoded range; validates min ≤ max, integers 0–100
 
 ### Changed
 

--- a/basic/config/ConfigHelper.php
+++ b/basic/config/ConfigHelper.php
@@ -48,6 +48,9 @@ class ConfigHelper
     public const PAX_OCC_LOW_MIN   = 'pax_occ_low_min';
     public const PAX_OCC_LOW_MAX   = 'pax_occ_low_max';
 
+    public const PAX_BAGS_RATIO_MIN = 'pax_bags_ratio_min';
+    public const PAX_BAGS_RATIO_MAX = 'pax_bags_ratio_max';
+
     public static function getRegistrationStart(): ?DateTime
     {
         $value = Config::get(self::REGISTRATION_START);
@@ -222,6 +225,16 @@ class ConfigHelper
     public static function getPaxOccLowMax(): int
     {
         return (int)(Config::get(self::PAX_OCC_LOW_MAX) ?? 80);
+    }
+
+    public static function getPaxBagsRatioMin(): int
+    {
+        return (int)(Config::get(self::PAX_BAGS_RATIO_MIN) ?? 20);
+    }
+
+    public static function getPaxBagsRatioMax(): int
+    {
+        return (int)(Config::get(self::PAX_BAGS_RATIO_MAX) ?? 35);
     }
 
 }

--- a/basic/helpers/PayloadEstimator.php
+++ b/basic/helpers/PayloadEstimator.php
@@ -133,7 +133,7 @@ class PayloadEstimator
             $paxWeight = $adults * $adultWeightKg + $children * $childWeightKg;
         }
 
-        $bags            = (int) round($paxTotal * mt_rand(20, 35) / 100);
+        $bags            = (int) round($paxTotal * mt_rand(CK::getPaxBagsRatioMin(), CK::getPaxBagsRatioMax()) / 100);
         $bagsWeight      = $bags * $baggageWeightKg;
         $remainingCargo  = max(0.0, $availablePayload - $paxWeight);
         $cargoLimit      = min($remainingCargo, (float) $config->cargo_capacity);

--- a/basic/messages/es/app.php
+++ b/basic/messages/es/app.php
@@ -477,6 +477,8 @@ return [
     'Pax high-traffic occupancy max (%)' => 'Vuelos de pasajeros (Días alta demanda). Máximo %',
     'Pax low-traffic occupancy min (%)' => 'Vuelos de pasajeros (Días baja demanda). Mínimo %',
     'Pax low-traffic occupancy max (%)' => 'Vuelos de pasajeros (Días baja demanda). Máximo %',
+    'Checked baggage ratio min (%)' => 'Ratio de maletas facturadas. Mínimo %',
+    'Checked baggage ratio max (%)' => 'Ratio de maletas facturadas. Máximo %',
     'Item' => 'Concepto',
     'Count' => 'Unidades',
     'Unit weight' => 'Peso unit.',

--- a/basic/migrations/m260823_085651_add_bags_ratio_config.php
+++ b/basic/migrations/m260823_085651_add_bags_ratio_config.php
@@ -1,0 +1,18 @@
+<?php
+
+use yii\db\Migration;
+
+class m260823_085651_add_bags_ratio_config extends Migration
+{
+    public function up()
+    {
+        $this->insert('config', ['key' => 'pax_bags_ratio_min', 'value' => '20']);
+        $this->insert('config', ['key' => 'pax_bags_ratio_max', 'value' => '35']);
+    }
+
+    public function down()
+    {
+        $this->delete('config', ['key' => 'pax_bags_ratio_min']);
+        $this->delete('config', ['key' => 'pax_bags_ratio_max']);
+    }
+}

--- a/basic/models/forms/SiteSettingsForm.php
+++ b/basic/models/forms/SiteSettingsForm.php
@@ -50,6 +50,9 @@ class SiteSettingsForm extends Model
     public $pax_occ_low_min;
     public $pax_occ_low_max;
 
+    public $pax_bags_ratio_min;
+    public $pax_bags_ratio_max;
+
     public function rules()
     {
         return [
@@ -62,7 +65,8 @@ class SiteSettingsForm extends Model
               'pax_adult_weight_kg','pax_child_weight_kg','pax_checked_baggage_kg',
               'pax_occ_cargo_min','pax_occ_cargo_max',
               'pax_occ_high_min','pax_occ_high_max',
-              'pax_occ_low_min','pax_occ_low_max'], 'trim'],
+              'pax_occ_low_min','pax_occ_low_max',
+              'pax_bags_ratio_min','pax_bags_ratio_max'], 'trim'],
 
             [['registration_start','registration_end'], 'date', 'format' => 'php:Y-m-d'],
             ['registration_start_location', 'filter', 'filter' => 'strtoupper'],
@@ -84,11 +88,13 @@ class SiteSettingsForm extends Model
 
             [['pax_occ_cargo_min','pax_occ_cargo_max',
               'pax_occ_high_min','pax_occ_high_max',
-              'pax_occ_low_min','pax_occ_low_max'], 'integer', 'min' => 0, 'max' => 100],
+              'pax_occ_low_min','pax_occ_low_max',
+              'pax_bags_ratio_min','pax_bags_ratio_max'], 'integer', 'min' => 0, 'max' => 100],
 
             ['pax_occ_cargo_min', 'compare', 'compareAttribute' => 'pax_occ_cargo_max', 'operator' => '<=', 'type' => 'number'],
             ['pax_occ_high_min',  'compare', 'compareAttribute' => 'pax_occ_high_max',  'operator' => '<=', 'type' => 'number'],
             ['pax_occ_low_min',   'compare', 'compareAttribute' => 'pax_occ_low_max',   'operator' => '<=', 'type' => 'number'],
+            ['pax_bags_ratio_min', 'compare', 'compareAttribute' => 'pax_bags_ratio_max', 'operator' => '<=', 'type' => 'number'],
 
             ['token_life_h', 'integer', 'min' => 1],
 
@@ -149,6 +155,9 @@ class SiteSettingsForm extends Model
             'pax_occ_high_max'  => Yii::t('app', 'Pax high-traffic occupancy max (%)'),
             'pax_occ_low_min'   => Yii::t('app', 'Pax low-traffic occupancy min (%)'),
             'pax_occ_low_max'   => Yii::t('app', 'Pax low-traffic occupancy max (%)'),
+
+            'pax_bags_ratio_min' => Yii::t('app', 'Checked baggage ratio min (%)'),
+            'pax_bags_ratio_max' => Yii::t('app', 'Checked baggage ratio max (%)'),
         ];
     }
 
@@ -185,6 +194,8 @@ class SiteSettingsForm extends Model
             CK::PAX_OCC_HIGH_MAX,
             CK::PAX_OCC_LOW_MIN,
             CK::PAX_OCC_LOW_MAX,
+            CK::PAX_BAGS_RATIO_MIN,
+            CK::PAX_BAGS_RATIO_MAX,
         ];
     }
 

--- a/basic/tests/functional/admin/SiteSettingsCest.php
+++ b/basic/tests/functional/admin/SiteSettingsCest.php
@@ -146,6 +146,24 @@ class SiteSettingsCest
         $I->assertEquals('0.2', Config::get(CK::CHARTER_RATIO));
     }
 
+    public function invalidBagsRatioIsNotSaved(\FunctionalTester $I)
+    {
+        $I->amLoggedInAs(2);
+        Config::set(CK::PAX_BAGS_RATIO_MIN, '20');
+        Config::set(CK::PAX_BAGS_RATIO_MAX, '35');
+
+        $I->amOnRoute('admin/site-settings');
+
+        $I->fillField('input[name="SiteSettingsForm[pax_bags_ratio_min]"]', '80');
+        $I->fillField('input[name="SiteSettingsForm[pax_bags_ratio_max]"]', '10');
+        $I->click('Save');
+
+        $I->see('Please fix the following errors');
+
+        $I->assertEquals('20', Config::get(CK::PAX_BAGS_RATIO_MIN));
+        $I->assertEquals('35', Config::get(CK::PAX_BAGS_RATIO_MAX));
+    }
+
     public function invalidEmailIsNotSaved(\FunctionalTester $I)
     {
         $I->amLoggedInAs(2);

--- a/basic/tests/unit/config/ConfigHelperTest.php
+++ b/basic/tests/unit/config/ConfigHelperTest.php
@@ -110,4 +110,24 @@ class ConfigHelperTest extends BaseUnitTest
         $this->assertEquals(40, CK::getPaxChildWeightKg());
         $this->assertEquals(15, CK::getPaxCheckedBaggageKg());
     }
+
+    public function testBagsRatioGettersReturnDefaults()
+    {
+        Config::delete(CK::PAX_BAGS_RATIO_MIN);
+        Config::delete(CK::PAX_BAGS_RATIO_MAX);
+        Yii::$app->cache->flush();
+
+        $this->assertEquals(20, CK::getPaxBagsRatioMin());
+        $this->assertEquals(35, CK::getPaxBagsRatioMax());
+    }
+
+    public function testBagsRatioGettersReturnConfiguredValues()
+    {
+        Config::set(CK::PAX_BAGS_RATIO_MIN, '25');
+        Config::set(CK::PAX_BAGS_RATIO_MAX, '40');
+        Yii::$app->cache->flush();
+
+        $this->assertEquals(25, CK::getPaxBagsRatioMin());
+        $this->assertEquals(40, CK::getPaxBagsRatioMax());
+    }
 }

--- a/basic/tests/unit/helpers/PayloadEstimatorTest.php
+++ b/basic/tests/unit/helpers/PayloadEstimatorTest.php
@@ -243,4 +243,28 @@ class PayloadEstimatorTest extends BaseUnitTest
             Yii::$app->cache->flush();
         }
     }
+
+    public function testBagsRatioIsRespected()
+    {
+        Config::set(CK::PAX_BAGS_RATIO_MIN, '50');
+        Config::set(CK::PAX_BAGS_RATIO_MAX, '55');
+        Yii::$app->cache->flush();
+
+        try {
+            $config = $this->makeConfig(['pax_capacity' => 180]);
+
+            for ($i = 0; $i < 30; $i++) {
+                $result   = $this->generate($config, 8000.0);
+                $paxTotal = $result['pax_adults'] + $result['pax_children'];
+                if ($paxTotal > 0) {
+                    $this->assertGreaterThanOrEqual((int) round($paxTotal * 0.50) - 1, $result['cargo_bags']);
+                    $this->assertLessThanOrEqual((int) round($paxTotal * 0.55) + 1, $result['cargo_bags']);
+                }
+            }
+        } finally {
+            Config::delete(CK::PAX_BAGS_RATIO_MIN);
+            Config::delete(CK::PAX_BAGS_RATIO_MAX);
+            Yii::$app->cache->flush();
+        }
+    }
 }

--- a/basic/views/admin/site-settings.php
+++ b/basic/views/admin/site-settings.php
@@ -61,6 +61,8 @@ $this->title = Yii::t('app', 'Site Settings');
 <?= $form->field($model, 'pax_occ_low_max')->input('number', ['min' => 0, 'max' => 100]) ?>
 <?= $form->field($model, 'pax_occ_high_min')->input('number', ['min' => 0, 'max' => 100]) ?>
 <?= $form->field($model, 'pax_occ_high_max')->input('number', ['min' => 0, 'max' => 100]) ?>
+<?= $form->field($model, 'pax_bags_ratio_min')->input('number', ['min' => 0, 'max' => 100]) ?>
+<?= $form->field($model, 'pax_bags_ratio_max')->input('number', ['min' => 0, 'max' => 100]) ?>
 
 <h3><?= Yii::t('app', 'Other') ?></h3>
 <?= $form->field($model, 'chunks_storage_path') ?>


### PR DESCRIPTION
## Summary
Extends the existing occupancy-ratio configuration pattern to the checked-baggage ratio, previously hardcoded as `mt_rand(20, 35)` in `PayloadEstimator::paxAndCargo()`.

- New config keys `pax_bags_ratio_min` / `pax_bags_ratio_max` (defaults 20 / 35), seeded via migration
- New `ConfigHelper` constants + getters (`getPaxBagsRatioMin()` / `getPaxBagsRatioMax()`)
- `PayloadEstimator` now reads the ratio from config instead of a hardcoded range
- Admin → Site Settings → Occupancy Ratios: two new fields at the end of the section, with `integer` (0–100) and `min <= max` compare validation, mirroring the existing occupancy fields
- Spanish translations added for the new field labels

## Tests
- `ConfigHelperTest::testBagsRatioGettersReturnDefaults` / `testBagsRatioGettersReturnConfiguredValues`
- `PayloadEstimatorTest::testBagsRatioIsRespected` — asserts generated `cargo_bags` stays within a configured narrow band
- `SiteSettingsCest::invalidBagsRatioIsNotSaved` — asserts min > max is rejected and the config is left unchanged

## Changelog
Entry added under `[Upcoming] - 1.14.0` in `CHANGELOG.md`; no version bump needed (already matches `params.php`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)