### PR TITLE
Add estimated ZFW row to load sheet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Pilot detail view: "Recent flights" table now shows a status icon (with tooltip) for each flight, matching the flight list view
 - `FlightStatusIconHelper::renderIcon()` centralizes the status icon markup, now shared by the flight list and pilot detail views
 - Admin settings → Occupancy Ratios: configurable checked-baggage ratio (default 20–35%), replacing the previously hardcoded range; validates min ≤ max, integers 0–100
+- Load sheet now shows an estimated ZFW (OEW + payload) in a single muted row below the payload total, labeled as approximate; hidden when the aircraft has no OEW configured
 
 ### Changed
 

--- a/basic/controllers/FlightController.php
+++ b/basic/controllers/FlightController.php
@@ -93,7 +93,7 @@ class FlightController extends Controller
                 CK::getPaxAdultWeightKg(),
                 CK::getPaxChildWeightKg(),
                 CK::getPaxCheckedBaggageKg(),
-                $model->aircraft?->aircraftConfiguration?->oew
+                $model->aircraft->aircraftConfiguration->oew
             );
         }
 

--- a/basic/controllers/FlightController.php
+++ b/basic/controllers/FlightController.php
@@ -92,7 +92,8 @@ class FlightController extends Controller
                 $model->cargo_paid_kg,
                 CK::getPaxAdultWeightKg(),
                 CK::getPaxChildWeightKg(),
-                CK::getPaxCheckedBaggageKg()
+                CK::getPaxCheckedBaggageKg(),
+                $model->aircraft?->aircraftConfiguration?->oew
             );
         }
 

--- a/basic/controllers/SubmittedFlightPlanController.php
+++ b/basic/controllers/SubmittedFlightPlanController.php
@@ -479,7 +479,8 @@ class SubmittedFlightPlanController extends Controller
                     $model->cargo_paid_kg,
                     CK::getPaxAdultWeightKg(),
                     CK::getPaxChildWeightKg(),
-                    CK::getPaxCheckedBaggageKg()
+                    CK::getPaxCheckedBaggageKg(),
+                    $model->aircraft?->aircraftConfiguration?->oew
                 );
             }
 

--- a/basic/controllers/SubmittedFlightPlanController.php
+++ b/basic/controllers/SubmittedFlightPlanController.php
@@ -480,7 +480,7 @@ class SubmittedFlightPlanController extends Controller
                     CK::getPaxAdultWeightKg(),
                     CK::getPaxChildWeightKg(),
                     CK::getPaxCheckedBaggageKg(),
-                    $model->aircraft?->aircraftConfiguration?->oew
+                    $model->aircraft->aircraftConfiguration->oew
                 );
             }
 

--- a/basic/helpers/PayloadEstimator.php
+++ b/basic/helpers/PayloadEstimator.php
@@ -49,6 +49,8 @@ class PayloadEstimator
      *
      * @param float|null $oewKg Aircraft configuration's OEW in kg, used to add an estimated ZFW (OEW + payload)
      *                           to the breakdown. Pass null when unavailable; estimatedZfw is then null too.
+     *                           Keep this optional with a null default: FlightReportController::generateFlightContext()
+     *                           calls this method without it, since the ACARS context only needs totalPayload.
      * @return array{crew: int, paxAdults: int, paxChildren: int, cargoBags: int, cargoPaidKg: int,
      *               adultW: float, childW: float, bagW: float, crewKg: float, adultsKg: float,
      *               childrenKg: float, paxTotal: int, paxKg: float, bagsKg: float, cargoKg: float,

--- a/basic/helpers/PayloadEstimator.php
+++ b/basic/helpers/PayloadEstimator.php
@@ -47,10 +47,12 @@ class PayloadEstimator
      * Shared by the load sheet views and the ACARS analysis context so the total payload
      * figure is calculated in exactly one place.
      *
+     * @param float|null $oewKg Aircraft configuration's OEW in kg, used to add an estimated ZFW (OEW + payload)
+     *                           to the breakdown. Pass null when unavailable; estimatedZfw is then null too.
      * @return array{crew: int, paxAdults: int, paxChildren: int, cargoBags: int, cargoPaidKg: int,
      *               adultW: float, childW: float, bagW: float, crewKg: float, adultsKg: float,
      *               childrenKg: float, paxTotal: int, paxKg: float, bagsKg: float, cargoKg: float,
-     *               totalPayload: float, pob: int}
+     *               totalPayload: float, pob: int, estimatedZfw: ?float}
      */
     public static function calculateLoadSheet(
         int $crew,
@@ -60,7 +62,8 @@ class PayloadEstimator
         int $cargoPaidKg,
         float $adultWeightKg,
         float $childWeightKg,
-        float $baggageWeightKg
+        float $baggageWeightKg,
+        ?float $oewKg = null
     ): array {
         $crewKg     = $crew * $adultWeightKg;
         $adultsKg   = $paxAdults * $adultWeightKg;
@@ -69,6 +72,7 @@ class PayloadEstimator
         $paxKg      = $adultsKg + $childrenKg;
         $bagsKg     = $cargoBags * $baggageWeightKg;
         $cargoKg    = $bagsKg + $cargoPaidKg;
+        $totalPayload = $crewKg + $paxKg + $cargoKg;
 
         return [
             'crew'         => $crew,
@@ -86,8 +90,9 @@ class PayloadEstimator
             'paxKg'        => $paxKg,
             'bagsKg'       => $bagsKg,
             'cargoKg'      => $cargoKg,
-            'totalPayload' => $crewKg + $paxKg + $cargoKg,
+            'totalPayload' => $totalPayload,
             'pob'          => $paxTotal + $crew,
+            'estimatedZfw' => $oewKg !== null ? $oewKg + $totalPayload : null,
         ];
     }
 

--- a/basic/messages/es/app.php
+++ b/basic/messages/es/app.php
@@ -491,4 +491,6 @@ return [
     'POB' => 'POB',
     'OEW' => 'OEW',
     'ZFW' => 'ZFW',
+    'Estimated ZFW' => 'ZFW estimado',
+    'may vary by aircraft/developer' => 'puede variar según avión/desarrollador',
 ];

--- a/basic/tests/unit/helpers/PayloadEstimatorTest.php
+++ b/basic/tests/unit/helpers/PayloadEstimatorTest.php
@@ -267,4 +267,21 @@ class PayloadEstimatorTest extends BaseUnitTest
             Yii::$app->cache->flush();
         }
     }
+
+    // --- calculateLoadSheet: estimated ZFW ---
+
+    public function testCalculateLoadSheetWithOewReturnsEstimatedZfw()
+    {
+        $result = PayloadEstimator::calculateLoadSheet(2, 100, 10, 20, 500, 84, 35, 13, 40000.0);
+
+        $this->assertEquals($result['totalPayload'], $result['estimatedZfw'] - 40000.0);
+        $this->assertEquals(40000.0 + $result['totalPayload'], $result['estimatedZfw']);
+    }
+
+    public function testCalculateLoadSheetWithoutOewReturnsNullEstimatedZfw()
+    {
+        $result = PayloadEstimator::calculateLoadSheet(2, 100, 10, 20, 500, 84, 35, 13);
+
+        $this->assertNull($result['estimatedZfw']);
+    }
 }

--- a/basic/views/partials/_load_sheet.php
+++ b/basic/views/partials/_load_sheet.php
@@ -24,6 +24,7 @@ $bagsKg       = $loadSheet['bagsKg'];
 $cargoKg      = $loadSheet['cargoKg'];
 $totalPayload = $loadSheet['totalPayload'];
 $pob          = $loadSheet['pob'];
+$estimatedZfw = $loadSheet['estimatedZfw'] ?? null;
 
 $fmt = fn(int $n) => number_format($n, 0, '.', ',') . ' Kg';
 ?>
@@ -104,6 +105,15 @@ $fmt = fn(int $n) => number_format($n, 0, '.', ',') . ' Kg';
                     <td class="text-end"></td>
                     <td class="text-end"><?= $fmt($totalPayload) ?></td>
                 </tr>
+
+                <?php if ($estimatedZfw !== null): ?>
+                <tr class="text-muted">
+                    <td><?= Yii::t('app', 'Estimated ZFW') ?> (<?= Yii::t('app', 'may vary by aircraft/developer') ?>)</td>
+                    <td class="text-center">&asymp;</td>
+                    <td class="text-end"></td>
+                    <td class="text-end"><?= $fmt((int) round($estimatedZfw)) ?></td>
+                </tr>
+                <?php endif; ?>
 
             </tbody>
         </table>


### PR DESCRIPTION
## Summary
- Show an estimated Zero Fuel Weight (OEW + payload) in the load sheet shown on flight and flight-plan views
- Displayed as a single muted row below the payload total, labeled "(may vary by aircraft/developer)" to make clear it's an approximation
- Hidden entirely when the aircraft has no OEW configured

## Details
- `PayloadEstimator::calculateLoadSheet()` now accepts an optional `?float $oewKg` and returns `estimatedZfw` (OEW + total payload), keeping the calculation in a single shared place (no logic in the view)
- `FlightController::actionView` and `SubmittedFlightPlanController::actionView` pass the aircraft's OEW through
- Spanish translations added for the new strings

## Test plan
- `vendor/bin/codecept run unit helpers/PayloadEstimatorTest.php`
- Manually reviewed a flight with a configured OEW (row shows) and one without (row hidden)

🤖 Generated with [Claude Code](https://claude.com/claude-code)